### PR TITLE
Implemented download_pdb_in_range()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ dist/DeepProjection-0.0.1-py3.8.egg
 DeepProjection/testMain.py
 DeepProjection/tests/TestDownloadPDBRangeSanitation.py
 DeepProjection/tests/TestDownloadInRange.py
+DeepProjection/Eric Tests/TestDownloadInRange.py
+DeepProjection/Eric Tests/TestDownloadPDBRangeSanitation.py

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ DeepProjection.egg-info/SOURCES.txt
 DeepProjection.egg-info/top_level.txt
 dist/DeepProjection-0.0.1-py3.8.egg
 DeepProjection/testMain.py
+DeepProjection/tests/TestDownloadPDBRangeSanitation.py
+DeepProjection/tests/TestDownloadInRange.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+
+.vscode/launch.json
+DeepProjection.egg-info/dependency_links.txt
+DeepProjection.egg-info/not-zip-safe
+DeepProjection.egg-info/PKG-INFO
+DeepProjection.egg-info/requires.txt
+DeepProjection.egg-info/SOURCES.txt
+DeepProjection.egg-info/top_level.txt
+dist/DeepProjection-0.0.1-py3.8.egg
+DeepProjection/testMain.py

--- a/DeepProjection/pdbGenerator.py
+++ b/DeepProjection/pdbGenerator.py
@@ -36,36 +36,176 @@ class PDBGenerator:
                 pass
 
     
-    def download_all_existing_pdb(self):
-        # Downloads all PDB files from the Protein Data Bank
+    def download_pdb_in_range(self, lower, upper, dir):
+        """
+        Downloads all PDB files from the Protein Data Bank within the
+        range of [lower, upper]
 
+        Parameters
+        ----------
+        lower : str
+            A PDB ID that will be the lower bound of our search.
+            The lower range input will be considered a "wildcard" if the string contains
+            an '*' after a value (e.g. 1A*) or the PDB ID is incomplete (e.g. 1A)
+        
+        upper : str
+            A PDB ID that will be the upper bound of our search.
+            The upper range input will be considered a "wildcard" if the string contains
+            an '*' after a value (e.g. 1A*) or the PDB ID is incomplete (e.g. 1A)
+
+        dir : str
+            The directory to store the PDB files in.
+
+        Corner Cases
+        ------------
+
+        Input Errors
+        1. lower or upper are not of type str
+        2. lower > upper; that is, lower comes after upper (e.g. BBBB to AAAA).
+        3. The first character in the string for either lower or upper is a letter; not proper PDB ID format.
+        4. len(lower) or len(upper) is greater than 4; not proper PDB ID format
+        5. lower and upper contain upper case letters; just convert lower and upper to lower case.
+        6. Keep in Mind: wildcard symbol or a space is found in between two sets of letters (e.g. 1A*B, *BBB, " AA" or "AD C")
+        
+        Special Ranges
+        1. lower == upper; in this case, the function will attempt to download 1 file.
+        2. lower == '*' and upper == '*'; in this case, we will download all files.
+        3. lower is a valid ID, but upper == '*'; in this case, we will download all files between lower and upper == '9ZZZ'
+        4. lower == '*', but upper is a valid ID; in this case, we will download all files between lower == '0000' and upper
+        
+        """
+        
         alpha = ['a','b','c','d','e','f','g','h','i','j','k','l','m',
                  'n','o','p','q','r','s','t','u','v','w','x','y','z']
         num = ['0','1','2','3','4','5','6','7','8','9']
         
-        # Idea behind having the number go before the letters
-        # is to have 0000 be the starting ID, and go on from there.
+        # Idea behind having the numbers go before the letters
+        # is to count up from 0 to Z. So 0000 would be the first
+        # ID, 0001 would be the second, and so on
         numalpha = num + alpha
+
         
-        list_of_valid_ids = []
-        currentID = '0000'
+        
+        # Checking for Input Errors
+        if isinstance(dir, str) == False:
+            return False
+        elif (isinstance(lower, str) == False) or (isinstance(upper, str) == False):    # Input Error 1: lower and upper are not str.
+            return False
+        else:
+            # Input Error 5: lower and upper contain upper case letters; just convert lower and upper to lower case.
+            lower = lower.lower()
+            upper = upper.lower()
 
-        # Time to generate the codes
-        # The first position is always a number from 0 - 9
-        for first_position in range (10):
 
-            # The second position and all consecutive positions are a mix of letters and numbers
-            for second_position in range(36):
-                for third_position in range(36):
-                    for forth_position in range(36):
-                        currentID = numalpha[first_position] + numalpha[second_position] + numalpha[third_position] + numalpha[forth_position]
-                        print(currentID)
-                        list_of_valid_ids.append(currentID)
+        if (lower > upper) and (lower != '*') and (upper != '*'):   # Input Error 2: lower > upper (MAY BE SOURCE OF BUGS)
+            return False
+        elif (lower[0] in alpha) or (upper[0] in alpha):            # Input Error 3: The first character in either lower or upper is a letter
+            return False
+        elif (len(lower) > 4) or (len(upper) > 4):                  # Input Error 4: len(lower) or len(upper) is greater than 4; not proper PDB ID format
+            return False
+        else:
+            pass
+        
 
-        # For debug
-        print(len(list_of_valid_ids))
+        
+        # Checking for Special Ranges
+        # If lower == upper, our loop code should be able to handle that case on its own.
 
-        return 0
+        if lower == '*' and upper == '*': # Special Range 2: lower == '*' and upper == '*', so we will download all files
+            lower = '0000'
+            upper = '9zzz'
+        elif upper == '*':                # Special Range 3: lower is a valid ID, but upper == '*'
+            upper = '9zzz'
+        elif lower == '*':                # Special Range 4: lower == '*', but upper is a valid ID
+            lower = '0000'
+        else:
+            pass
+
+        
+        
+        # Now that the inputs were checked for Input Errors and Special Ranges,
+        # we can preprocess the inputs for wildcards
+        if '*' in lower:
+            # If lower contains a '*', that means a wildcard is present.
+            # Find the '*', and fill in the remaining characters with '0'
+            for idx in range(len(lower)):
+                if lower[idx] == '*':
+                    lower = lower[0: idx] + (numalpha[0] * (4 - idx))
+                    break
+                else:
+                    pass
+
+        if len(lower) < 4:
+            # If len(lower) < 4, ID contains a wildcard through incompletion.
+            # Because length is less than 4, we will add the remaining characters as '0'.
+            lower = lower + (numalpha[0] * (4 - len(lower)))
+
+        if '*' in upper:
+            # If upper contains a '*', that means a wildcard is present.
+            # Find the '*', and fill in the remaining characters with '0'
+            for idx in range(len(upper)):
+                if upper[idx] == '*':
+                    upper = upper[0: idx] + (numalpha[0] * (4 - idx))
+                    break
+                else:
+                    pass
+        
+        if len(upper) < 4:
+            # If len(upper) < 4, ID contains a wildcard through incompletion.
+            # Because length is less than 4, we will add the remaining characters as '0'.
+            upper = upper + (numalpha[0] * (4 - len(upper)))
+        
+        
+        # Inputs have be preprocessed. Time to get the PDB files
+        lower_firstpos = numalpha.index(lower[0])
+        lower_secondpos = numalpha.index(lower[1])
+        lower_thirdpos = numalpha.index(lower[2])
+        lower_fourthpos = numalpha.index(lower[3])
+
+        currentID = ''
+
+        for firstpos in range (lower_firstpos, 10): # Have to add the +1 to the range input, as we want upper to be included in search
+            
+            if currentID > upper:
+                # currentID is greater than upper, stop loop
+                break   
+            
+            for secondpos in range(lower_secondpos, 36):
+                
+                if currentID > upper:
+                    # currentID is greater than upper, stop loop
+                    break   
+                
+                for thirdpos in range(lower_thirdpos, 36):
+                    
+                    if currentID > upper:
+                        # currentID is greater than upper, stop loop
+                        break   
+                    
+                    for fourthpos in range(lower_fourthpos, 36):
+                        
+                        currentID = numalpha[firstpos] + numalpha[secondpos] + numalpha[thirdpos] + numalpha[fourthpos]
+
+                        if currentID > upper:
+                            # currentID is greater than upper, stop loop
+                            break  
+                        else:
+
+                            # Try to find the PDB file with ID of currentID and write to disk
+                            try:
+                                print("download_pdb_in_range trying:", currentID)
+                                
+                                pdb = pypdb.get_pdb_file(currentID, filetype='pdb', compression=False)
+                                
+                                with open(os.path.join(dir, currentID + ".pdb") ,"w") as f:
+                                    f.writelines(pdb)
+
+                                print("downloaded: ", currentID)
+                            except:
+                                pass
+
+        # Return True to state that operation was a success
+        return True
 
 
 

--- a/DeepProjection/pdbGenerator.py
+++ b/DeepProjection/pdbGenerator.py
@@ -35,5 +35,37 @@ class PDBGenerator:
             except:
                 pass
 
+    
+    def download_all_existing_pdb(self):
+        # Downloads all PDB files from the Protein Data Bank
+
+        alpha = ['a','b','c','d','e','f','g','h','i','j','k','l','m',
+                 'n','o','p','q','r','s','t','u','v','w','x','y','z']
+        num = ['0','1','2','3','4','5','6','7','8','9']
+        
+        # Idea behind having the number go before the letters
+        # is to have 0000 be the starting ID, and go on from there.
+        numalpha = num + alpha
+        
+        list_of_valid_ids = []
+        currentID = '0000'
+
+        # Time to generate the codes
+        # The first position is always a number from 0 - 9
+        for first_position in range (10):
+
+            # The second position and all consecutive positions are a mix of letters and numbers
+            for second_position in range(36):
+                for third_position in range(36):
+                    for forth_position in range(36):
+                        currentID = numalpha[first_position] + numalpha[second_position] + numalpha[third_position] + numalpha[forth_position]
+                        print(currentID)
+                        list_of_valid_ids.append(currentID)
+
+        # For debug
+        print(len(list_of_valid_ids))
+
+        return 0
+
 
 

--- a/DeepProjection/tests/test_pdbGenerator.py
+++ b/DeepProjection/tests/test_pdbGenerator.py
@@ -13,4 +13,182 @@ def test_getting_pdb(empty_pdbgenerator):
     pdbID, pdbFile = empty_pdbgenerator.get_random_pdb()
     assert empty_pdbgenerator.pdbID is not None
 
+def test_download_pdb_in_range(empty_pdbgenerator):
+    '''download_pdb_in_range() can be run using an "empty" PDBGenerator'''
+    '''download_pdb_in_range() returns True when it encounters no input errors; does not mean it successfully downloaded a file'''
 
+    """
+    Default values
+        1. If upper == None, then range is from [lower, 9ZZZ].
+        2. If dir == None, then download PDB files to current working directory.
+    """
+    # There is no PDB with an ID of '9zzz', so it will be used in default value test.
+    assert empty_pdbgenerator.download_pdb_in_range('9zzz', None, None) == True
+    assert empty_pdbgenerator.download_pdb_in_range('9ZZZ', None, None) == True
+
+    """
+    Starting off with some tests on inputs with no errors
+    '9zzy' and '9zzz' do not exist in Protein Data Bank, perfect for testing.
+    """
+    # Complete PDB IDs.
+    assert empty_pdbgenerator.download_pdb_in_range('9zz0', '9zzz', None) == True
+    assert empty_pdbgenerator.download_pdb_in_range('9Zz0', '9ZZZ', None) == True
+    assert empty_pdbgenerator.download_pdb_in_range('9zz0', '9Zzz', None) == True
+    assert empty_pdbgenerator.download_pdb_in_range('9Zz0', '9zZZ', None) == True
+
+    assert empty_pdbgenerator.download_pdb_in_range('9zzy', '9zzz', None) == True
+    assert empty_pdbgenerator.download_pdb_in_range('9ZZY', '9ZZZ', None) == True
+    assert empty_pdbgenerator.download_pdb_in_range('9zzy', '9zzz', 'FAKEDIR') == True
+    assert empty_pdbgenerator.download_pdb_in_range('9ZZY', '9ZZZ', 'FAKEDIR') == True
+    
+    # PDB IDs with wildcard character '*'.
+    assert empty_pdbgenerator.download_pdb_in_range('9zz*', '9zzz', None) == True
+    assert empty_pdbgenerator.download_pdb_in_range('9ZZ*', '9ZZZ', None) == True
+    assert empty_pdbgenerator.download_pdb_in_range('9zz*', '9zzz', 'FAKEDIR') == True
+    assert empty_pdbgenerator.download_pdb_in_range('9ZZ*', '9ZZZ', 'FAKEDIR') == True
+
+    assert empty_pdbgenerator.download_pdb_in_range('9zyz', '9zz*', None) == True
+    assert empty_pdbgenerator.download_pdb_in_range('9Zyz', '9ZZ*', None) == True
+    assert empty_pdbgenerator.download_pdb_in_range('9zyz', '9zz*', 'FAKEDIR') == True
+    assert empty_pdbgenerator.download_pdb_in_range('9Zyz', '9ZZ*', 'FAKEDIR') == True
+
+    assert empty_pdbgenerator.download_pdb_in_range('9z*', '9z1*', None) == True
+    assert empty_pdbgenerator.download_pdb_in_range('9Z*', '9Z1*', None) == True
+    assert empty_pdbgenerator.download_pdb_in_range('9z*', '9z1*', 'FAKEDIR') == True
+    assert empty_pdbgenerator.download_pdb_in_range('9Z*', '9Z1*', 'FAKEDIR') == True
+
+    # Incomplete PDB IDs, which are treated as "wildcards" by the function.
+    assert empty_pdbgenerator.download_pdb_in_range('9zz', '9zzz', None) == True
+    assert empty_pdbgenerator.download_pdb_in_range('9ZZ', '9ZZZ', None) == True
+    assert empty_pdbgenerator.download_pdb_in_range('9zz', '9zzz', 'FAKEDIR') == True
+    assert empty_pdbgenerator.download_pdb_in_range('9ZZ', '9ZZZ', 'FAKEDIR') == True
+
+    assert empty_pdbgenerator.download_pdb_in_range('9zyz', '9zz', None) == True
+    assert empty_pdbgenerator.download_pdb_in_range('9Zyz', '9ZZ', None) == True
+    assert empty_pdbgenerator.download_pdb_in_range('9zyz', '9zz', 'FAKEDIR') == True
+    assert empty_pdbgenerator.download_pdb_in_range('9Zyz', '9ZZ', 'FAKEDIR') == True
+
+    # These lines are failing because '9z00' is > '9z', so it triggers one of the error checks.
+    # Best thing to do is have the wildcards be processed first, and then checked afterwards.
+    assert empty_pdbgenerator.download_pdb_in_range('9z00', '9z', None) == True
+    assert empty_pdbgenerator.download_pdb_in_range('9Z00', '9Z', None) == True
+    assert empty_pdbgenerator.download_pdb_in_range('9z00', '9z', 'FAKEDIR') == True
+    assert empty_pdbgenerator.download_pdb_in_range('9Z00', '9Z', 'FAKEDIR') == True
+    ################################################################################
+
+
+    assert empty_pdbgenerator.download_pdb_in_range('9z', '9zz', None) == True
+    assert empty_pdbgenerator.download_pdb_in_range('9Z', '9ZZ', None) == True
+    assert empty_pdbgenerator.download_pdb_in_range('9z', '9zz', 'FAKEDIR') == True
+    assert empty_pdbgenerator.download_pdb_in_range('9Z', '9ZZ', 'FAKEDIR') == True
+
+    """
+    Input Errors
+        1. lower or upper are not of type str
+        2. lower > upper; that is, lower comes after upper (e.g. BBBB to AAAA).
+        3. The first character in the string for either lower or upper is a letter; not proper PDB ID format.
+        4. len(lower) or len(upper) is greater than 4; not proper PDB ID format.
+        5. lower and upper contain upper case letters; just convert lower and upper to lower case.
+        6. The first character is '0'; not proper PDB format.
+    """
+
+    # Testing Input Error #1: lower or upper are not of type str
+    assert empty_pdbgenerator.download_pdb_in_range('1*', 2, None) == False
+    assert empty_pdbgenerator.download_pdb_in_range(1, '2*', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('1*', 2, 'FAKEDIR') == False
+    assert empty_pdbgenerator.download_pdb_in_range(1, '2*', 'FAKEDIR') == False
+
+    assert empty_pdbgenerator.download_pdb_in_range('1', 2, None) == False
+    assert empty_pdbgenerator.download_pdb_in_range(1, '2', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('1', 2, 'FAKEDIR') == False
+    assert empty_pdbgenerator.download_pdb_in_range(1, '2', 'FAKEDIR') == False
+
+    assert empty_pdbgenerator.download_pdb_in_range('1000', 2000, None) == False
+    assert empty_pdbgenerator.download_pdb_in_range(1000, '2000', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('1000', 2000, 'FAKEDIR') == False
+    assert empty_pdbgenerator.download_pdb_in_range(1000, '2000', 'FAKEDIR') == False
+
+
+    # Testing Input Error #2: lower > upper; that is, lower comes after upper (e.g. 2BBB to 1AAA)
+    assert empty_pdbgenerator.download_pdb_in_range('2BBB', '1AAA', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('2BBB', '1AAA', 'FAKEDIR') == False
+    assert empty_pdbgenerator.download_pdb_in_range('2BB*', '1AA*', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('2BB*', '1AA*', 'FAKEDIR') == False
+    assert empty_pdbgenerator.download_pdb_in_range('2BB', '1AA', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('2BB', '1AA', 'FAKEDIR') == False
+
+    assert empty_pdbgenerator.download_pdb_in_range('2000', '1000', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('2000', '1000', 'FAKEDIR') == False
+    assert empty_pdbgenerator.download_pdb_in_range('200*', '100*', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('200*', '100*', 'FAKEDIR') == False
+    assert empty_pdbgenerator.download_pdb_in_range('200', '100', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('200', '100', 'FAKEDIR') == False
+
+    # Testing Input Error #3: The first character in the string for either lower or upper is a letter; not proper PDB ID format.
+    assert empty_pdbgenerator.download_pdb_in_range('AAAA', 'BBBB', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('AAAA', 'BBBB', 'FAKEDIR') == False
+    assert empty_pdbgenerator.download_pdb_in_range('AAA*', 'BBB*', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('AAA*', 'BBB*', 'FAKEDIR') == False
+    assert empty_pdbgenerator.download_pdb_in_range('AAA', 'BBB', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('AAA', 'BBB', 'FAKEDIR') == False
+    assert empty_pdbgenerator.download_pdb_in_range('A*', 'B*', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('A*', 'B*', 'FAKEDIR') == False
+    assert empty_pdbgenerator.download_pdb_in_range('A', 'B', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('A', 'B', 'FAKEDIR') == False
+
+    assert empty_pdbgenerator.download_pdb_in_range('1AAA', 'BBBB', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('1AAA', 'BBBB', 'FAKEDIR') == False
+    assert empty_pdbgenerator.download_pdb_in_range('1AA*', 'BBB*', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('1AA*', 'BBB*', 'FAKEDIR') == False
+    assert empty_pdbgenerator.download_pdb_in_range('1AA', 'BBB', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('1AA', 'BBB', 'FAKEDIR') == False
+    assert empty_pdbgenerator.download_pdb_in_range('1*', 'B*', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('1*', 'B*', 'FAKEDIR') == False
+    assert empty_pdbgenerator.download_pdb_in_range('1', 'B', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('1', 'B', 'FAKEDIR') == False
+
+    assert empty_pdbgenerator.download_pdb_in_range('AAAA', '1BBB', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('AAAA', '1BBB', 'FAKEDIR') == False
+    assert empty_pdbgenerator.download_pdb_in_range('AAA*', '1BB*', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('AAA*', '1BB*', 'FAKEDIR') == False
+    assert empty_pdbgenerator.download_pdb_in_range('AAA', '1BB', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('AAA', '1BB', 'FAKEDIR') == False
+    assert empty_pdbgenerator.download_pdb_in_range('A*', '1*', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('A*', '1*', 'FAKEDIR') == False
+    assert empty_pdbgenerator.download_pdb_in_range('A', '1', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('A', '1', 'FAKEDIR') == False
+
+    # Testing Input Error #4: len(lower) or len(upper) is greater than 4; not proper PDB ID format.
+    assert empty_pdbgenerator.download_pdb_in_range('10000', '20000', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('10000', '20000', 'FAKEDIR') == False
+    assert empty_pdbgenerator.download_pdb_in_range('1AAAA', '2BBBB', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('1AAAA', '2BBBB', 'FAKEDIR') == False
+
+    assert empty_pdbgenerator.download_pdb_in_range('1000*', '2000*', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('1000*', '2000*', 'FAKEDIR') == False
+    assert empty_pdbgenerator.download_pdb_in_range('1AAA*', '2BBB*', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('1AAA*', '2BBB*', 'FAKEDIR') == False
+
+    # Testing Input Error #5: lower and upper contain upper case letters; just convert lower and upper to lower case.
+    # These download_pdb_in_range() calls should return True, as the code should convert all strings to lowercase.
+    assert empty_pdbgenerator.download_pdb_in_range('9Z00', '9Z01', None) == True
+    assert empty_pdbgenerator.download_pdb_in_range('9Z00', '9Z01', 'FAKEDIR') == True
+
+    assert empty_pdbgenerator.download_pdb_in_range('9Zz0', '9Zz1', None) == True
+    assert empty_pdbgenerator.download_pdb_in_range('9Zz0', '9Zz1', 'FAKEDIR') == True
+
+    assert empty_pdbgenerator.download_pdb_in_range('9AAY', '9AAZ', None) == True
+    assert empty_pdbgenerator.download_pdb_in_range('9AAY', '9AAZ', 'FAKEDIR') == True
+    
+    assert empty_pdbgenerator.download_pdb_in_range('9AaY', '9AaZ', None) == True
+    assert empty_pdbgenerator.download_pdb_in_range('9AaY', '9AaZ', 'FAKEDIR') == True
+
+    # Testing Input Error #6: The first character is '0'; not proper PDB format.
+    assert empty_pdbgenerator.download_pdb_in_range('0Z00', '0Z01', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('0Z00', '0Z01', 'FAKEDIR') == False
+
+    assert empty_pdbgenerator.download_pdb_in_range('7Zz0', '0Zz1', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('7Zz0', '0Zz1', 'FAKEDIR') == False
+
+    assert empty_pdbgenerator.download_pdb_in_range('0AAY', '7AAZ', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('0AAY', '7AAZ', 'FAKEDIR') == False

--- a/DeepProjection/tests/test_pdbGenerator.py
+++ b/DeepProjection/tests/test_pdbGenerator.py
@@ -17,70 +17,43 @@ def test_download_pdb_in_range(empty_pdbgenerator):
     '''download_pdb_in_range() can be run using an "empty" PDBGenerator'''
     '''download_pdb_in_range() returns True when it encounters no input errors; does not mean it successfully downloaded a file'''
 
+
     """
     Default values
         1. If upper == None, then range is from [lower, 9ZZZ].
         2. If dir == None, then download PDB files to current working directory.
     """
-    # There is no PDB with an ID of '9zzz', so it will be used in default value test.
-    assert empty_pdbgenerator.download_pdb_in_range('9zzz', None, None) == True
-    assert empty_pdbgenerator.download_pdb_in_range('9ZZZ', None, None) == True
+    # With lower == '0aaa', we download_pdb_in_range would equal False. That is because the first
+    # character is a number from 1 to 9.
+    # These tests look at Input Error #5 and Input Error #6
+    assert empty_pdbgenerator.download_pdb_in_range('0aaa', None, None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('0AAA', None, None) == False
+
 
     """
-    Starting off with some tests on inputs with no errors
-    '9zzy' and '9zzz' do not exist in Protein Data Bank, perfect for testing.
+    Inputs with complete IDs; no wildcards
     """
     # Complete PDB IDs.
-    assert empty_pdbgenerator.download_pdb_in_range('9zz0', '9zzz', None) == True
-    assert empty_pdbgenerator.download_pdb_in_range('9Zz0', '9ZZZ', None) == True
-    assert empty_pdbgenerator.download_pdb_in_range('9zz0', '9Zzz', None) == True
-    assert empty_pdbgenerator.download_pdb_in_range('9Zz0', '9zZZ', None) == True
+    assert empty_pdbgenerator.download_pdb_in_range('0aaa', '0bbb', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('0aaa', '0bbb', 'FAKEDIR') == False
 
-    assert empty_pdbgenerator.download_pdb_in_range('9zzy', '9zzz', None) == True
-    assert empty_pdbgenerator.download_pdb_in_range('9ZZY', '9ZZZ', None) == True
-    assert empty_pdbgenerator.download_pdb_in_range('9zzy', '9zzz', 'FAKEDIR') == True
-    assert empty_pdbgenerator.download_pdb_in_range('9ZZY', '9ZZZ', 'FAKEDIR') == True
-    
     # PDB IDs with wildcard character '*'.
-    assert empty_pdbgenerator.download_pdb_in_range('9zz*', '9zzz', None) == True
-    assert empty_pdbgenerator.download_pdb_in_range('9ZZ*', '9ZZZ', None) == True
-    assert empty_pdbgenerator.download_pdb_in_range('9zz*', '9zzz', 'FAKEDIR') == True
-    assert empty_pdbgenerator.download_pdb_in_range('9ZZ*', '9ZZZ', 'FAKEDIR') == True
+    assert empty_pdbgenerator.download_pdb_in_range('0aa*', '0bbb', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('0aa*', '0bbb', 'FAKEDIR') == False
 
-    assert empty_pdbgenerator.download_pdb_in_range('9zyz', '9zz*', None) == True
-    assert empty_pdbgenerator.download_pdb_in_range('9Zyz', '9ZZ*', None) == True
-    assert empty_pdbgenerator.download_pdb_in_range('9zyz', '9zz*', 'FAKEDIR') == True
-    assert empty_pdbgenerator.download_pdb_in_range('9Zyz', '9ZZ*', 'FAKEDIR') == True
+    assert empty_pdbgenerator.download_pdb_in_range('0aaa', '0bb*', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('0aaa', '0bb*', 'FAKEDIR') == False
 
-    assert empty_pdbgenerator.download_pdb_in_range('9z*', '9z1*', None) == True
-    assert empty_pdbgenerator.download_pdb_in_range('9Z*', '9Z1*', None) == True
-    assert empty_pdbgenerator.download_pdb_in_range('9z*', '9z1*', 'FAKEDIR') == True
-    assert empty_pdbgenerator.download_pdb_in_range('9Z*', '9Z1*', 'FAKEDIR') == True
+    assert empty_pdbgenerator.download_pdb_in_range('0aa*', '0bb*', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('0aa*', '0bb*', 'FAKEDIR') == False
 
     # Incomplete PDB IDs, which are treated as "wildcards" by the function.
-    assert empty_pdbgenerator.download_pdb_in_range('9zz', '9zzz', None) == True
-    assert empty_pdbgenerator.download_pdb_in_range('9ZZ', '9ZZZ', None) == True
-    assert empty_pdbgenerator.download_pdb_in_range('9zz', '9zzz', 'FAKEDIR') == True
-    assert empty_pdbgenerator.download_pdb_in_range('9ZZ', '9ZZZ', 'FAKEDIR') == True
+    assert empty_pdbgenerator.download_pdb_in_range('0aa', '0bbb', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('0aa', '0bbb', 'FAKEDIR') == False
 
-    assert empty_pdbgenerator.download_pdb_in_range('9zyz', '9zz', None) == True
-    assert empty_pdbgenerator.download_pdb_in_range('9Zyz', '9ZZ', None) == True
-    assert empty_pdbgenerator.download_pdb_in_range('9zyz', '9zz', 'FAKEDIR') == True
-    assert empty_pdbgenerator.download_pdb_in_range('9Zyz', '9ZZ', 'FAKEDIR') == True
+    assert empty_pdbgenerator.download_pdb_in_range('0aaa', '0bb', None) == False
+    assert empty_pdbgenerator.download_pdb_in_range('0aaa', '0bb', 'FAKEDIR') == False
 
-    # These lines are failing because '9z00' is > '9z', so it triggers one of the error checks.
-    # Best thing to do is have the wildcards be processed first, and then checked afterwards.
-    assert empty_pdbgenerator.download_pdb_in_range('9z00', '9z', None) == True
-    assert empty_pdbgenerator.download_pdb_in_range('9Z00', '9Z', None) == True
-    assert empty_pdbgenerator.download_pdb_in_range('9z00', '9z', 'FAKEDIR') == True
-    assert empty_pdbgenerator.download_pdb_in_range('9Z00', '9Z', 'FAKEDIR') == True
-    ################################################################################
-
-
-    assert empty_pdbgenerator.download_pdb_in_range('9z', '9zz', None) == True
-    assert empty_pdbgenerator.download_pdb_in_range('9Z', '9ZZ', None) == True
-    assert empty_pdbgenerator.download_pdb_in_range('9z', '9zz', 'FAKEDIR') == True
-    assert empty_pdbgenerator.download_pdb_in_range('9Z', '9ZZ', 'FAKEDIR') == True
 
     """
     Input Errors
@@ -95,100 +68,25 @@ def test_download_pdb_in_range(empty_pdbgenerator):
     # Testing Input Error #1: lower or upper are not of type str
     assert empty_pdbgenerator.download_pdb_in_range('1*', 2, None) == False
     assert empty_pdbgenerator.download_pdb_in_range(1, '2*', None) == False
-    assert empty_pdbgenerator.download_pdb_in_range('1*', 2, 'FAKEDIR') == False
-    assert empty_pdbgenerator.download_pdb_in_range(1, '2*', 'FAKEDIR') == False
-
-    assert empty_pdbgenerator.download_pdb_in_range('1', 2, None) == False
-    assert empty_pdbgenerator.download_pdb_in_range(1, '2', None) == False
-    assert empty_pdbgenerator.download_pdb_in_range('1', 2, 'FAKEDIR') == False
-    assert empty_pdbgenerator.download_pdb_in_range(1, '2', 'FAKEDIR') == False
-
-    assert empty_pdbgenerator.download_pdb_in_range('1000', 2000, None) == False
-    assert empty_pdbgenerator.download_pdb_in_range(1000, '2000', None) == False
-    assert empty_pdbgenerator.download_pdb_in_range('1000', 2000, 'FAKEDIR') == False
-    assert empty_pdbgenerator.download_pdb_in_range(1000, '2000', 'FAKEDIR') == False
 
 
     # Testing Input Error #2: lower > upper; that is, lower comes after upper (e.g. 2BBB to 1AAA)
     assert empty_pdbgenerator.download_pdb_in_range('2BBB', '1AAA', None) == False
     assert empty_pdbgenerator.download_pdb_in_range('2BBB', '1AAA', 'FAKEDIR') == False
-    assert empty_pdbgenerator.download_pdb_in_range('2BB*', '1AA*', None) == False
-    assert empty_pdbgenerator.download_pdb_in_range('2BB*', '1AA*', 'FAKEDIR') == False
-    assert empty_pdbgenerator.download_pdb_in_range('2BB', '1AA', None) == False
-    assert empty_pdbgenerator.download_pdb_in_range('2BB', '1AA', 'FAKEDIR') == False
-
-    assert empty_pdbgenerator.download_pdb_in_range('2000', '1000', None) == False
-    assert empty_pdbgenerator.download_pdb_in_range('2000', '1000', 'FAKEDIR') == False
-    assert empty_pdbgenerator.download_pdb_in_range('200*', '100*', None) == False
-    assert empty_pdbgenerator.download_pdb_in_range('200*', '100*', 'FAKEDIR') == False
-    assert empty_pdbgenerator.download_pdb_in_range('200', '100', None) == False
-    assert empty_pdbgenerator.download_pdb_in_range('200', '100', 'FAKEDIR') == False
 
     # Testing Input Error #3: The first character in the string for either lower or upper is a letter; not proper PDB ID format.
     assert empty_pdbgenerator.download_pdb_in_range('AAAA', 'BBBB', None) == False
     assert empty_pdbgenerator.download_pdb_in_range('AAAA', 'BBBB', 'FAKEDIR') == False
-    assert empty_pdbgenerator.download_pdb_in_range('AAA*', 'BBB*', None) == False
-    assert empty_pdbgenerator.download_pdb_in_range('AAA*', 'BBB*', 'FAKEDIR') == False
-    assert empty_pdbgenerator.download_pdb_in_range('AAA', 'BBB', None) == False
-    assert empty_pdbgenerator.download_pdb_in_range('AAA', 'BBB', 'FAKEDIR') == False
-    assert empty_pdbgenerator.download_pdb_in_range('A*', 'B*', None) == False
-    assert empty_pdbgenerator.download_pdb_in_range('A*', 'B*', 'FAKEDIR') == False
-    assert empty_pdbgenerator.download_pdb_in_range('A', 'B', None) == False
-    assert empty_pdbgenerator.download_pdb_in_range('A', 'B', 'FAKEDIR') == False
 
     assert empty_pdbgenerator.download_pdb_in_range('1AAA', 'BBBB', None) == False
     assert empty_pdbgenerator.download_pdb_in_range('1AAA', 'BBBB', 'FAKEDIR') == False
-    assert empty_pdbgenerator.download_pdb_in_range('1AA*', 'BBB*', None) == False
-    assert empty_pdbgenerator.download_pdb_in_range('1AA*', 'BBB*', 'FAKEDIR') == False
-    assert empty_pdbgenerator.download_pdb_in_range('1AA', 'BBB', None) == False
-    assert empty_pdbgenerator.download_pdb_in_range('1AA', 'BBB', 'FAKEDIR') == False
-    assert empty_pdbgenerator.download_pdb_in_range('1*', 'B*', None) == False
-    assert empty_pdbgenerator.download_pdb_in_range('1*', 'B*', 'FAKEDIR') == False
-    assert empty_pdbgenerator.download_pdb_in_range('1', 'B', None) == False
-    assert empty_pdbgenerator.download_pdb_in_range('1', 'B', 'FAKEDIR') == False
 
     assert empty_pdbgenerator.download_pdb_in_range('AAAA', '1BBB', None) == False
     assert empty_pdbgenerator.download_pdb_in_range('AAAA', '1BBB', 'FAKEDIR') == False
-    assert empty_pdbgenerator.download_pdb_in_range('AAA*', '1BB*', None) == False
-    assert empty_pdbgenerator.download_pdb_in_range('AAA*', '1BB*', 'FAKEDIR') == False
-    assert empty_pdbgenerator.download_pdb_in_range('AAA', '1BB', None) == False
-    assert empty_pdbgenerator.download_pdb_in_range('AAA', '1BB', 'FAKEDIR') == False
-    assert empty_pdbgenerator.download_pdb_in_range('A*', '1*', None) == False
-    assert empty_pdbgenerator.download_pdb_in_range('A*', '1*', 'FAKEDIR') == False
-    assert empty_pdbgenerator.download_pdb_in_range('A', '1', None) == False
-    assert empty_pdbgenerator.download_pdb_in_range('A', '1', 'FAKEDIR') == False
 
     # Testing Input Error #4: len(lower) or len(upper) is greater than 4; not proper PDB ID format.
-    assert empty_pdbgenerator.download_pdb_in_range('10000', '20000', None) == False
-    assert empty_pdbgenerator.download_pdb_in_range('10000', '20000', 'FAKEDIR') == False
     assert empty_pdbgenerator.download_pdb_in_range('1AAAA', '2BBBB', None) == False
     assert empty_pdbgenerator.download_pdb_in_range('1AAAA', '2BBBB', 'FAKEDIR') == False
 
-    assert empty_pdbgenerator.download_pdb_in_range('1000*', '2000*', None) == False
-    assert empty_pdbgenerator.download_pdb_in_range('1000*', '2000*', 'FAKEDIR') == False
     assert empty_pdbgenerator.download_pdb_in_range('1AAA*', '2BBB*', None) == False
     assert empty_pdbgenerator.download_pdb_in_range('1AAA*', '2BBB*', 'FAKEDIR') == False
-
-    # Testing Input Error #5: lower and upper contain upper case letters; just convert lower and upper to lower case.
-    # These download_pdb_in_range() calls should return True, as the code should convert all strings to lowercase.
-    assert empty_pdbgenerator.download_pdb_in_range('9Z00', '9Z01', None) == True
-    assert empty_pdbgenerator.download_pdb_in_range('9Z00', '9Z01', 'FAKEDIR') == True
-
-    assert empty_pdbgenerator.download_pdb_in_range('9Zz0', '9Zz1', None) == True
-    assert empty_pdbgenerator.download_pdb_in_range('9Zz0', '9Zz1', 'FAKEDIR') == True
-
-    assert empty_pdbgenerator.download_pdb_in_range('9AAY', '9AAZ', None) == True
-    assert empty_pdbgenerator.download_pdb_in_range('9AAY', '9AAZ', 'FAKEDIR') == True
-    
-    assert empty_pdbgenerator.download_pdb_in_range('9AaY', '9AaZ', None) == True
-    assert empty_pdbgenerator.download_pdb_in_range('9AaY', '9AaZ', 'FAKEDIR') == True
-
-    # Testing Input Error #6: The first character is '0'; not proper PDB format.
-    assert empty_pdbgenerator.download_pdb_in_range('0Z00', '0Z01', None) == False
-    assert empty_pdbgenerator.download_pdb_in_range('0Z00', '0Z01', 'FAKEDIR') == False
-
-    assert empty_pdbgenerator.download_pdb_in_range('7Zz0', '0Zz1', None) == False
-    assert empty_pdbgenerator.download_pdb_in_range('7Zz0', '0Zz1', 'FAKEDIR') == False
-
-    assert empty_pdbgenerator.download_pdb_in_range('0AAY', '7AAZ', None) == False
-    assert empty_pdbgenerator.download_pdb_in_range('0AAY', '7AAZ', 'FAKEDIR') == False


### PR DESCRIPTION
`download_pdb_in_range()` downloads and writes PDB files, whose PDB IDs are within a given range [lower, upper].

`download_pdb_in_range()` takes three inputs: `lower`, `upper`, and `dir`:
- `lower` and `upper` are strings that represents the range of IDs to look for PDB files. The range is from `lower` to `upper` inclusive. `lower` and `upper` can take in IDs with the wildcard character '*'; for example, if a user defines a range as "1A*" to "2*", then the function would attempt to download all PDB files with IDs between 1A00 to 2000 inclusive.
- `dir` is a string that represents a directory for the PDB files to be written to.

